### PR TITLE
Improve energy efficiency by applying Cache Energy Pattern

### DIFF
--- a/app/src/main/java/com/tachibana/downloader/core/TLSSocketFactory.java
+++ b/app/src/main/java/com/tachibana/downloader/core/TLSSocketFactory.java
@@ -38,7 +38,7 @@ import javax.net.ssl.SSLSocketFactory;
 public class TLSSocketFactory extends SSLSocketFactory
 {
     private SSLSocketFactory delegate;
-    
+
     public TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException
     {
         SSLContext context = SSLContext.getInstance("TLS");

--- a/app/src/main/java/com/tachibana/downloader/core/TLSSocketFactory.java
+++ b/app/src/main/java/com/tachibana/downloader/core/TLSSocketFactory.java
@@ -27,6 +27,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -37,11 +38,16 @@ import javax.net.ssl.SSLSocketFactory;
 public class TLSSocketFactory extends SSLSocketFactory
 {
     private SSLSocketFactory delegate;
-
+    
     public TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException
     {
         SSLContext context = SSLContext.getInstance("TLS");
         context.init(null, null, null);
+        SSLSessionContext sslSessionContext = context.getServerSessionContext();
+        int sessionCacheSize = sslSessionContext.getSessionCacheSize();
+        if (sessionCacheSize > 0) {
+            sslSessionContext.setSessionCacheSize(0);
+        }
         delegate = context.getSocketFactory();
     }
 


### PR DESCRIPTION
This improves the energy efficiency of TachibanaGeneralLaboratories by applying the Cache Energy Pattern for mobile applications.

The energy pattern was applied in TLSSocketFactory.java . The general idea is to avoid performing unnecessary operations by increasing the size of the cache used. In particular, when a SSLContext is created, if the size of the cache has a limit, it's set to have no limit.