### PR TITLE
Added a referer header specification option to download dialog

### DIFF
--- a/app/src/main/java/com/tachibana/downloader/core/HttpConnection.java
+++ b/app/src/main/java/com/tachibana/downloader/core/HttpConnection.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2018 Tachibana General Laboratories, LLC
  * Copyright (C) 2018 Yaroslav Pronin <proninyaroslav@mail.ru>
+ * Copyright (C) 2020 8176135 <elsecaller@8176135.xyz>
  *
  * This file is part of Download Navi.
  *

--- a/app/src/main/java/com/tachibana/downloader/core/HttpConnection.java
+++ b/app/src/main/java/com/tachibana/downloader/core/HttpConnection.java
@@ -49,6 +49,7 @@ public class HttpConnection implements Runnable
     private TLSSocketFactory socketFactory;
     private Listener listener;
     private int timeout = DEFAULT_TIMEOUT;
+    private String referer;
 
     public interface Listener
     {
@@ -69,6 +70,7 @@ public class HttpConnection implements Runnable
         this.socketFactory = new TLSSocketFactory();
     }
 
+    public void setReferer(String referer) { this.referer = referer; }
     public void setListener(Listener listener)
     {
         this.listener = listener;
@@ -105,6 +107,9 @@ public class HttpConnection implements Runnable
                     conn.setRequestProperty("Cookie", cookiesString);
                 }
 
+                if (referer != null && !referer.isEmpty()) {
+                    conn.setRequestProperty("Referer", referer);
+                }
 
                 if (conn instanceof HttpsURLConnection)
                     ((HttpsURLConnection) conn).setSSLSocketFactory(socketFactory);

--- a/app/src/main/java/com/tachibana/downloader/ui/adddownload/AddDownloadParams.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/adddownload/AddDownloadParams.java
@@ -40,6 +40,7 @@ public class AddDownloadParams extends BaseObservable
     private String description;
     private String mimeType = "application/octet-stream";
     private String etag;
+    private String referer;
     private String userAgent;
     private int numPieces = DownloadInfo.MIN_PIECES;
     private long totalBytes = -1;
@@ -139,6 +140,16 @@ public class AddDownloadParams extends BaseObservable
     public void setEtag(String etag)
     {
         this.etag = etag;
+    }
+
+    public String getReferer()
+    {
+        return referer;
+    }
+
+    public void setReferer(String referer)
+    {
+        this.referer = referer;
     }
 
     public String getUserAgent()

--- a/app/src/main/java/com/tachibana/downloader/ui/adddownload/AddDownloadParams.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/adddownload/AddDownloadParams.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2018, 2019 Tachibana General Laboratories, LLC
  * Copyright (C) 2018, 2019 Yaroslav Pronin <proninyaroslav@mail.ru>
+ * Copyright (C) 2020, 8176135 <elsecaller@8176135.xyz>
  *
  * This file is part of Download Navi.
  *

--- a/app/src/main/java/com/tachibana/downloader/ui/adddownload/AddDownloadViewModel.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/adddownload/AddDownloadViewModel.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2019 Tachibana General Laboratories, LLC
  * Copyright (C) 2019 Yaroslav Pronin <proninyaroslav@mail.ru>
+ * Copyright (C) 2020 8176135 <elsecaller@8176135.xyz>
  *
  * This file is part of Download Navi.
  *

--- a/app/src/main/java/com/tachibana/downloader/ui/adddownload/AddDownloadViewModel.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/adddownload/AddDownloadViewModel.java
@@ -209,7 +209,7 @@ public class AddDownloadViewModel extends AndroidViewModel
         }
 
         fetchTask = new FetchLinkTask(this);
-        fetchTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params.getUrl());
+        fetchTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params.getUrl(), params.getReferer());
     }
 
     private static class FetchLinkTask extends AsyncTask<String, Void, Throwable>
@@ -249,7 +249,8 @@ public class AddDownloadViewModel extends AndroidViewModel
                 return e;
             }
             connection.setTimeout(viewModel.get().pref.timeout());
-
+            connection.setReferer(params[1]);
+            
             NetworkInfo netInfo = viewModel.get().systemFacade.getActiveNetworkInfo();
             if (netInfo == null || !netInfo.isConnected())
                 return new ConnectException("Network is disconnected");
@@ -387,6 +388,9 @@ public class AddDownloadViewModel extends AndroidViewModel
 
         ArrayList<Header> headers = new ArrayList<>();
         headers.add(new Header(info.id, "ETag", params.getEtag()));
+        if (params.getReferer() != null && !params.getReferer().isEmpty()) {
+            headers.add(new Header(info.id, "Referer", params.getReferer()));
+        }
 
         /* TODO: rewrite to WorkManager */
         /* Sync wait inserting */

--- a/app/src/main/res/layout/dialog_add_download.xml
+++ b/app/src/main/res/layout/dialog_add_download.xml
@@ -321,7 +321,8 @@
 
                     <RelativeLayout
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp">
 
                         <com.google.android.material.textfield.TextInputLayout
                             android:id="@+id/layout_checksum"

--- a/app/src/main/res/layout/dialog_add_download.xml
+++ b/app/src/main/res/layout/dialog_add_download.xml
@@ -353,6 +353,49 @@
                             android:src="@drawable/ic_content_copy_grey600_48dp"
                             android:visibility="@{viewModel.showClipboardButton ? View.VISIBLE : View.GONE}" />
                     </RelativeLayout>
+
+                    <TextView
+                        android:id="@+id/referer_title"
+                        style="@style/TitleText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/referer" />
+
+                    <RelativeLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/layout_referer"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_toStartOf="@+id/referer_clipboard_button"
+                            app:hintEnabled="false">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/referer"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/referer_description"
+                                android:inputType="text|textNoSuggestions"
+                                android:text="@={viewModel.params.referer}" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <ImageButton
+                            android:id="@+id/referer_clipboard_button"
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:layout_alignParentEnd="true"
+                            android:layout_marginStart="8dp"
+                            android:layout_marginTop="9dp"
+                            android:background="?attr/dialogRoundRipple"
+                            android:contentDescription="@string/clipboard"
+                            android:padding="8dp"
+                            android:scaleType="fitCenter"
+                            android:src="@drawable/ic_content_copy_grey600_48dp"
+                            android:visibility="@{viewModel.showClipboardButton ? View.VISIBLE : View.GONE}" />
+                    </RelativeLayout>
+
                 </LinearLayout>
             </net.cachapa.expandablelayout.ExpandableLayout>
         </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -314,4 +314,6 @@ href="http://www.gnu.org/copyleft/gpl.html">
 جنو العمومية الإصدارv3 (GPLv3)</a><br><br>
    <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">سياسة الخصوصية</a>]]></string>
     <string name="about_changelog">سِجل التغييرات</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -304,4 +304,6 @@
     Download Navi ödənişsiz proqram təminatıdır,<a href="http://www.gnu.org/copyleft/gpl.html">GNU Ümumi İctimai Lisenziyası v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Gizlilik siyasəti</a> şərtləri altında buraxılıb]]></string>
     <string name="about_changelog">Dəyişiklik jurnalı</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -304,4 +304,6 @@
     Download Navi is free software, released under the terms of the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Privacy Policy</a>]]></string>
     <string name="about_changelog">Changelog</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -308,4 +308,6 @@
     Download Navi je volný software, vydaný za podmínek <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Zásady ochrany osobních údajů</a>]]></string>
     <string name="about_changelog">Seznam změn</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -304,4 +304,6 @@
     Download Navi ist freie Software, veröffentlicht unter den Bedingungen der <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Datenschutz-Bestimmungen</a>]]></string>
     <string name="about_changelog">Änderungsprotokoll</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -301,4 +301,6 @@
     <string name="about_title">Acerca de Download Navi</string>
     <string name="about_description"><![CDATA[Para más información y para ayudar en el proyecto: <a href="https://github.com/TachibanaGeneralLaboratories/download-navi">https://github.com/TachibanaGeneralLaboratories/download-navi</a><br><br>Download Navi es un administrador de descargas libre y de código abierto para Android 4.4+<br><br>Download Navi es software libre, publicado bajo los términos de la <a href="http://www.gnu.org/copyleft/gpl.html">Licencia Pública General de GNU v3 (GPLv3)</a><br><br><a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Política de privacidad</a>]]></string>
     <string name="about_changelog">Registro de cambios</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -304,4 +304,6 @@
     Download Navi est un logiciel gratuit, publié selon les termes de la <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Politique de confidentialité</a>]]></string>
     <string name="about_changelog">Journal des modifications</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -304,4 +304,6 @@
     Download Navi मुफ्त सॉफ्टवेयर है, की शर्तों के तहत जारी <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">गोपनीयता नीति</a>]]></string>
     <string name="about_changelog">परिवर्तन लॉग</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -302,4 +302,6 @@
     Download Navi adalah perangkat lunak bebas, dirilis dibawah perlindungan <a href="http://www.gnu.org/copyleft/gpl.html">Lisensi Publik Umum GNU v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Kebijakan Privasi</a>]]></string>
     <string name="about_changelog">Catatan perubahan</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -302,4 +302,6 @@
     Download Navi adalah perangkat lunak bebas, dirilis dibawah perlindungan <a href="http://www.gnu.org/copyleft/gpl.html">Lisensi Publik Umum GNU v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Kebijakan Privasi</a>]]></string>
     <string name="about_changelog">Catatan perubahan</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -304,4 +304,6 @@
     Download Navi is free software, rilasciato sotto licenza <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Privacy Policy</a>]]></string>
     <string name="about_changelog">Changelog</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -302,4 +302,6 @@
     Download Navi は <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a> の条件の下でリリースされたフリーソフトウェアです<br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">個人情報保護方針</a>]]></string>
     <string name="about_changelog">更新履歴</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -304,4 +304,6 @@
     Download Navi é um software livre, lançado sob os termos da licença <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Política de Privacidade</a>]]></string>
     <string name="about_changelog">Alterações</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -308,4 +308,6 @@
     Download Navi является свободным программным обеспечением, выпущенным в соответствии с условиями лицензииe <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Политика конфидециальности</a>]]></string>
     <string name="about_changelog">Изменения</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -308,4 +308,6 @@
     Download Navi je bezplatný softvér vydaný za podmienok <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Zásady ochrany osobných údajov</a>]]></string>
     <string name="about_changelog">Zoznam zmien</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -306,4 +306,6 @@
     Download Navi је бесплатан софтвер, објављен под условима <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Полиса приватности</a>]]></string>
     <string name="about_changelog">Евиденција измена</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -304,4 +304,6 @@
     Download Navi, <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a> şartları altında yayınlanan ücretsiz bir yazılımdır<br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Gizlilik Politikası</a>]]></string>
     <string name="about_changelog">Değişiklik günlüğü</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -302,4 +302,6 @@
     Download Navi là phần mềm tự do, được phân phối theo <a href="http://www.gnu.org/copyleft/gpl.html">Giấy phép công cộng GNU phiên bản 3 (GPLv3)</a><br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">Chính sách quyền riêng tư</a>]]></string>
     <string name="about_changelog">Nhật kí thay đổi</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -302,4 +302,6 @@
     Download Navi 是一款自由软件，遵循许可 <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a> 的条款发布<br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">隐私政策</a>]]></string>
     <string name="about_changelog">更新日志</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -302,4 +302,6 @@
     Download Navi 是一款自由軟體，遵循 <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License v3 (GPLv3)</a> 的許可條款發佈<br><br>
     <a href="https://github.com/TachibanaGeneralLaboratories/download-navi/blob/HEAD/Privacy.md">隱私政策</a>]]></string>
     <string name="about_changelog">更新日誌</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Referer Header</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,8 @@
     <string name="add_download_error_invalid_url">Unable to add download: invalid URL</string>
     <string name="checksum">Checksum</string>
     <string name="add_dialog_checksum_description">MD5, SHA-256</string>
+    <string name="referer">Referer</string>
+    <string name="referer_description">Optional Referer URL</string>
     <string name="error_invalid_checksum">Invalid checksum</string>
 
     <!-- Add user agent dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,7 +111,7 @@
     <string name="checksum">Checksum</string>
     <string name="add_dialog_checksum_description">MD5, SHA-256</string>
     <string name="referer">Referer</string>
-    <string name="referer_description">Optional Referer URL</string>
+    <string name="referer_description">Referer Header</string>
     <string name="error_invalid_checksum">Invalid checksum</string>
 
     <!-- Add user agent dialog -->


### PR DESCRIPTION
I added another text field after checksum in the add download advanced drop down section, which allows you to specify the referer header for downloads.

Some sites (e.g. pixiv.net) will return a 403 error if you don't have a correct referer header when trying to download their content. This allows you to at least work around that manually by copying and pasting the parent url.

Things to note about this pull request:
- Added 2 lines to the strings.xml, and just copied and pasted that into the translations. I'm not sure how you get the actual translations for them. Also referer being misspelt in the http specifications doesn't help either.
- I used the misspelt "Referer" as the label to match the header that it is adding, though maybe "Referrer" will be clearer.