### PR TITLE
make share only if files exist.

### DIFF
--- a/app/src/main/java/com/tachibana/downloader/ui/main/DownloadsFragment.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/main/DownloadsFragment.java
@@ -416,7 +416,8 @@ public abstract class DownloadsFragment extends Fragment
                     if (intent != null) {
                         startActivity(Intent.createChooser(intent, getString(R.string.share_via)));
                     } else {
-                        Toast.makeText(activity.getApplicationContext(), getString(R.string.unable_sharing), Toast.LENGTH_SHORT).show();
+                        Toast.makeText(activity.getApplicationContext(),
+                                getResources().getQuantityString(R.plurals.unable_sharing, items.size()), Toast.LENGTH_SHORT).show();
                     }
                 }));
     }

--- a/app/src/main/java/com/tachibana/downloader/ui/main/DownloadsFragment.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/main/DownloadsFragment.java
@@ -33,6 +33,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -411,9 +412,12 @@ public abstract class DownloadsFragment extends Fragment
         disposables.add(Observable.fromIterable(selections)
                 .toList()
                 .subscribe((items) -> {
-                    startActivity(Intent.createChooser(
-                            Utils.makeFileShareIntent(activity.getApplicationContext(), items),
-                            getString(R.string.share_via)));
+                    Intent intent = Utils.makeFileShareIntent(activity.getApplicationContext(), items);
+                    if (intent != null) {
+                        startActivity(Intent.createChooser(intent, getString(R.string.share_via)));
+                    } else {
+                        Toast.makeText(activity.getApplicationContext(), getString(R.string.unable_sharing), Toast.LENGTH_SHORT).show();
+                    }
                 }));
     }
 

--- a/app/src/main/java/com/tachibana/downloader/ui/main/FinishedDownloadsFragment.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/main/FinishedDownloadsFragment.java
@@ -192,7 +192,8 @@ public class FinishedDownloadsFragment extends DownloadsFragment
         if (intent != null) {
             startActivity(Intent.createChooser(intent, getString(R.string.share_via)));
         } else {
-            Toast.makeText(activity.getApplicationContext(), getString(R.string.unable_sharing), Toast.LENGTH_SHORT).show();
+            Toast.makeText(activity.getApplicationContext(),
+                    getResources().getQuantityString(R.plurals.unable_sharing, 1), Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/java/com/tachibana/downloader/ui/main/FinishedDownloadsFragment.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/main/FinishedDownloadsFragment.java
@@ -187,11 +187,13 @@ public class FinishedDownloadsFragment extends DownloadsFragment
         viewModel.deleteDownload(info, withFile);
     }
 
-    private void shareDownload(DownloadItem item)
-    {
-        startActivity(Intent.createChooser(
-                Utils.makeFileShareIntent(activity.getApplicationContext(), Collections.singletonList(item)),
-                getString(R.string.share_via)));
+    private void shareDownload(DownloadItem item) {
+        Intent intent = Utils.makeFileShareIntent(activity.getApplicationContext(), Collections.singletonList(item));
+        if (intent != null) {
+            startActivity(Intent.createChooser(intent, getString(R.string.share_via)));
+        } else {
+            Toast.makeText(activity.getApplicationContext(), getString(R.string.unable_sharing), Toast.LENGTH_SHORT).show();
+        }
     }
 
     private void shareUrl(DownloadItem item)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="download_list_empty">No downloads</string>
     <string name="share_url">Share URL</string>
     <string name="file_not_available">file not available!</string>
+    <string name="unable_sharing">The file(s) cannot be shared.</string>
     <!-- Navigation drawer -->
     <!-- Category -->
     <string name="drawer_category">Category</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,7 +122,10 @@
     <string name="download_list_empty">No downloads</string>
     <string name="share_url">Share URL</string>
     <string name="file_not_available">file not available!</string>
-    <string name="unable_sharing">The file(s) cannot be shared.</string>
+    <plurals name="unable_sharing">
+        <item quantity="one">The file cannot be shared.</item>
+        <item quantity="other">The files cannot be shared.</item>
+    </plurals>
     <!-- Navigation drawer -->
     <!-- Category -->
     <string name="drawer_category">Category</string>


### PR DESCRIPTION
This pull request fixes issue #167  where files are checking if they exist before the share menu is opened, if the file or files are missing or deleted returns an error message.

## Pre-launch Checklist

- [x] I read the [Contributor Guide](CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- If you made changes to the code:
  - [ ] I added new tests to check the change I am making or feature I am adding.
  - [ ] All existing and new tests are passing.
