### PR TITLE
fixed rowser overlaping issue and crash issue

### DIFF
--- a/app/src/main/java/com/tachibana/downloader/ui/browser/BrowserActivity.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/browser/BrowserActivity.java
@@ -379,34 +379,56 @@ public class BrowserActivity extends AppCompatActivity
         return true;
     }
 
+    // fix the error crashing on searchbar input clicked it crashes 
+    /**
+     * Crash logs comment can be removed 
+     * 
+     * 2023-05-28 16:09:19.725 15414-15414/com.tachibana.downloader E/ACRA: ACRA caught a NullPointerException for com.tachibana.downloader
+    java.lang.NullPointerException: Attempt to invoke interface method 'android.view.MenuItem android.view.MenuItem.setVisible(boolean)' on a null object reference
+        at com.tachibana.downloader.ui.browser.BrowserActivity.onPrepareOptionsMenu(BrowserActivity.java:350)
+        at android.app.Activity.onPreparePanel(Activity.java:4334)
+        at androidx.activity.ComponentActivity.onPreparePanel(ComponentActivity.java:512)
+        at androidx.fragment.app.FragmentActivity.onPrepareOptionsPanel(FragmentActivity.java:485)
+        at androidx.fragment.app.FragmentActivity.onPreparePanel(FragmentActivity.java:470)
+        at androidx.appcompat.view.WindowCallbackWrapper.onPreparePanel(WindowCallbackWrapper.java:100)
+        at 
+     */
     @Override
-    public boolean onPrepareOptionsMenu(Menu menu)
-    {
+    public boolean onPrepareOptionsMenu(Menu menu) {
         BrowserViewModel.UrlFetchState state = viewModel.observeUrlFetchState().getValue();
+
         MenuItem refresh = menu.findItem(R.id.refresh_menu);
         MenuItem stop = menu.findItem(R.id.stop_menu);
-        boolean fetching = state == BrowserViewModel.UrlFetchState.FETCHING ||
-                state == BrowserViewModel.UrlFetchState.PAGE_STARTED;
-        refresh.setVisible(!fetching);
-        stop.setVisible(fetching);
+        if (refresh != null && stop != null) {
+            boolean fetching = state == BrowserViewModel.UrlFetchState.FETCHING ||
+                    state == BrowserViewModel.UrlFetchState.PAGE_STARTED;
+            refresh.setVisible(!fetching);
+            stop.setVisible(!fetching);
+        }
 
         MenuItem forward = menu.findItem(R.id.forward_menu);
-        forward.setVisible(webView.canGoForward());
+        if (forward != null) {
+            forward.setVisible(webView.canGoForward());
+        }
 
         MenuItem desktopVersion = menu.findItem(R.id.desktop_version_menu);
-        desktopVersion.setChecked(viewModel.isDesktopMode());
+        if (desktopVersion != null) {
+            desktopVersion.setChecked(viewModel.isDesktopMode());
+        }
 
         MenuItem addBookmark = menu.findItem(R.id.add_bookmark_menu);
         MenuItem editBookmark = menu.findItem(R.id.edit_bookmark_menu);
-        addBookmark.setVisible(!isCurrentPageBookmarked);
-        editBookmark.setVisible(isCurrentPageBookmarked);
+        if (addBookmark != null && editBookmark != null) {
+            addBookmark.setVisible(!isCurrentPageBookmarked);
+            editBookmark.setVisible(isCurrentPageBookmarked);
+        }
 
         return true;
     }
 
+    // edited for go measure nothing wrong with it 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item)
-    {
+    public boolean onOptionsItemSelected(MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == R.id.forward_menu) {
             if (webView.canGoForward())
@@ -442,7 +464,6 @@ public class BrowserActivity extends AppCompatActivity
 
         return true;
     }
-
     private void makeShareDialog(String url)
     {
         if (url == null)

--- a/app/src/main/java/com/tachibana/downloader/ui/browser/BrowserActivity.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/browser/BrowserActivity.java
@@ -380,19 +380,6 @@ public class BrowserActivity extends AppCompatActivity
     }
 
     // fix the error crashing on searchbar input clicked it crashes 
-    /**
-     * Crash logs comment can be removed 
-     * 
-     * 2023-05-28 16:09:19.725 15414-15414/com.tachibana.downloader E/ACRA: ACRA caught a NullPointerException for com.tachibana.downloader
-    java.lang.NullPointerException: Attempt to invoke interface method 'android.view.MenuItem android.view.MenuItem.setVisible(boolean)' on a null object reference
-        at com.tachibana.downloader.ui.browser.BrowserActivity.onPrepareOptionsMenu(BrowserActivity.java:350)
-        at android.app.Activity.onPreparePanel(Activity.java:4334)
-        at androidx.activity.ComponentActivity.onPreparePanel(ComponentActivity.java:512)
-        at androidx.fragment.app.FragmentActivity.onPrepareOptionsPanel(FragmentActivity.java:485)
-        at androidx.fragment.app.FragmentActivity.onPreparePanel(FragmentActivity.java:470)
-        at androidx.appcompat.view.WindowCallbackWrapper.onPreparePanel(WindowCallbackWrapper.java:100)
-        at 
-     */
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         BrowserViewModel.UrlFetchState state = viewModel.observeUrlFetchState().getValue();

--- a/app/src/main/java/com/tachibana/downloader/ui/browser/BrowserActivity.java
+++ b/app/src/main/java/com/tachibana/downloader/ui/browser/BrowserActivity.java
@@ -217,7 +217,7 @@ public class BrowserActivity extends AppCompatActivity
                     DataBindingUtil.setContentView(this, R.layout.activity_browser_bottom_app_bar);
             binding.setLifecycleOwner(this);
             binding.setViewModel(viewModel);
-            setSupportActionBar(binding.bottomBar);
+            setSupportActionBar(binding.toolbar); // change this to toolbar instead of bottomBar
             webView = binding.webView;
             addressLayout = binding.addressBar.addressLayout;
             addressInput = binding.addressBar.addressInput;

--- a/app/src/main/res/layout/activity_browser_bottom_app_bar.xml
+++ b/app/src/main/res/layout/activity_browser_bottom_app_bar.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- just switched the top browser app to gravity bottom and change the progress to above input to fix the overlap issue -->
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
@@ -23,26 +24,33 @@
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
-        <com.google.android.material.bottomappbar.BottomAppBar
+        <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/bottom_bar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
+            android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:background="?attr/toolbarColor"
-            android:transitionName="actionBar"
-            app:popupTheme="?attr/popupTheme"
-            android:theme="@style/ThemeOverlay.MaterialComponents.ActionBar"
-            android:focusable="true">
-
+            android:background="?attr/toolbarColor">
             <include
-                android:id="@+id/address_bar"
-                layout="@layout/browser_address_bar"
+                android:id="@+id/progress"
+                layout="@layout/browser_progress_bar"
                 app:viewModel="@{viewModel}" />
-        </com.google.android.material.bottomappbar.BottomAppBar>
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/toolbarColor"
+                app:layout_scrollFlags="scroll|enterAlways"
+                android:transitionName="actionBar"
+                app:popupTheme="?attr/popupTheme"
+                android:theme="@style/ThemeOverlay.MaterialComponents.ActionBar"
+                android:focusable="true"
+                tools:ignore="UnusedAttribute">
 
-        <include
-            android:id="@+id/progress"
-            layout="@layout/browser_progress_bar"
-            app:viewModel="@{viewModel}" />
+                <include
+                    android:id="@+id/address_bar"
+                    layout="@layout/browser_address_bar"
+                    app:viewModel="@{viewModel}" />
+            </androidx.appcompat.widget.Toolbar>
+        </com.google.android.material.appbar.AppBarLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/browser_address_bar.xml
+++ b/app/src/main/res/layout/browser_address_bar.xml
@@ -1,47 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- icons overlapping fixed -->
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <import type="android.view.View" />
+
         <variable
             name="viewModel"
             type="com.tachibana.downloader.ui.browser.BrowserViewModel" />
     </data>
 
     <merge>
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/browser_secure_connection"
-            app:srcCompat="@drawable/ic_lock_outline_menu_24dp"
-            android:visibility="@{viewModel.isSecureConnection ? View.VISIBLE : View.GONE}" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/address_layout"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="8dp"
-            android:layout_centerVertical="true"
-            app:boxBackgroundMode="none"
-            app:hintEnabled="false"
-            app:endIconMode="custom"
-            app:endIconDrawable="@drawable/ic_cancel_grey600_24dp"
-            android:focusable="true"
-            android:focusableInTouchMode="true">
+            android:orientation="horizontal">
+            <ImageView
+                android:layout_width="40dp"
+                android:layout_height="match_parent"
+                android:contentDescription="@string/browser_secure_connection"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:visibility="@{viewModel.isSecureConnection ? View.VISIBLE : View.GONE}"
+                app:srcCompat="@drawable/ic_lock_outline_menu_24dp" />
 
-            <com.tachibana.downloader.ui.customview.FixHintTextInputEditText
-                android:id="@+id/address_input"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/address_layout"
                 android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:minHeight="?attr/actionBarSize"
-                android:hint="@string/browser_address_bar_hint"
-                android:background="@null"
-                android:inputType="text|textNoSuggestions"
-                android:imeOptions="actionSearch"
-                android:selectAllOnFocus="true"
-                android:text="@={viewModel.url}" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_height="wrap_content"
+                app:boxBackgroundMode="none"
+                app:endIconDrawable="@drawable/ic_cancel_grey600_24dp"
+                app:endIconMode="custom"
+                app:hintEnabled="false">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/address_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@null"
+                    android:hint="@string/browser_address_bar_hint"
+                    android:imeOptions="actionSearch"
+                    android:inputType="text|textNoSuggestions"
+                    android:selectAllOnFocus="true"
+                    android:text="@={viewModel.url}" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
     </merge>
 </layout>

--- a/app/src/main/res/menu/browser.xml
+++ b/app/src/main/res/menu/browser.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- changed for the concept to fix the overlaping search bottom bar view -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:id="@+id/refresh_menu"
         android:icon="@drawable/ic_refresh_menu_24dp"
-        android:title=""
-        app:showAsAction="always" />
+        android:title="refresh"
+        app:showAsAction="ifRoom" />
 
     <item android:id="@+id/stop_menu"
         android:icon="@drawable/ic_close_menu_24dp"
-        android:title=""
-        app:showAsAction="always" />
+        android:title="close"
+        app:showAsAction="ifRoom" />
 
     <item android:id="@+id/forward_menu"
         android:title="@string/browser_forward_arrow"


### PR DESCRIPTION
The browser had an two major issues overlapping menus and view , and then crashing on input due to onPrepareOptionsMenu method in BrowserActivity. The error message suggests that there is a NullPointerException occurring when trying to invoke the setVisible method on a null object reference.

## Pre-launch Checklist

- [x] I read the [Contributor Guide](CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- If you made changes to the code:
  - [x] BrowserActivity : I changed the onPrepareOptionsMenu to fix the crash log that was present due to setVisible have left comments t explain the code here is the error and the fix to the crash log below 
  ```
2023-05-28 16:09:19.725 15414-15414/com.tachibana.downloader E/ACRA: ACRA caught a NullPointerException for com.tachibana.downloader
    java.lang.NullPointerException: Attempt to invoke interface method 'android.view.MenuItem android.view.MenuItem.setVisible(boolean)' on a null object reference
        at com.tachibana.downloader.ui.browser.BrowserActivity.onPrepareOptionsMenu(BrowserActivity.java:350)
        at android.app.Activity.onPreparePanel(Activity.java:4334)
        at androidx.activity.ComponentActivity.onPreparePanel(ComponentActivity.java:512)
        at androidx.fragment.app.FragmentActivity.onPrepareOptionsPanel(FragmentActivity.java:485)
        at androidx.fragment.app.FragmentActivity.onPreparePanel(FragmentActivity.java:470)
        at androidx.appcompat.view.WindowCallbackWrapper.onPreparePanel(WindowCallbackWrapper.java:100)
        at 
```
     ```
 @Override
    public boolean onPrepareOptionsMenu(Menu menu) {
        BrowserViewModel.UrlFetchState state = viewModel.observeUrlFetchState().getValue();

        MenuItem refresh = menu.findItem(R.id.refresh_menu);
        MenuItem stop = menu.findItem(R.id.stop_menu);
        if (refresh != null && stop != null) {
            boolean fetching = state == BrowserViewModel.UrlFetchState.FETCHING ||
                    state == BrowserViewModel.UrlFetchState.PAGE_STARTED;
            refresh.setVisible(!fetching);
            stop.setVisible(!fetching);
        }

        MenuItem forward = menu.findItem(R.id.forward_menu);
        if (forward != null) {
            forward.setVisible(webView.canGoForward());
        }

        MenuItem desktopVersion = menu.findItem(R.id.desktop_version_menu);
        if (desktopVersion != null) {
            desktopVersion.setChecked(viewModel.isDesktopMode());
        }

        MenuItem addBookmark = menu.findItem(R.id.add_bookmark_menu);
        MenuItem editBookmark = menu.findItem(R.id.edit_bookmark_menu);
        if (addBookmark != null && editBookmark != null) {
            addBookmark.setVisible(!isCurrentPageBookmarked);
            editBookmark.setVisible(isCurrentPageBookmarked);
        }

        return true;
    }
     ```
  - [x] All existing and new tests are passing.
  - [x] Updated layouts to fix the overlapping issue changes made in browser_address_bar.xml and activity_browser_bottom_app_bar.xml fixed the issue perfectly comments available to explain the changes made 
  - [x]The crash issue on Browser and overlap in the browser search bar are fixed.  
